### PR TITLE
Use typescript naming convention rule

### DIFF
--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -27,6 +27,10 @@ const config = {
       'warn',
       { private: '^_', protected: '^_' }
     ],
+    '@typescript-eslint/naming-convention': [
+      'error'
+      //
+    ],
     '@typescript-eslint/no-dynamic-delete': 'error',
     '@typescript-eslint/no-extra-non-null-assertion': 'error',
     '@typescript-eslint/no-extraneous-class': 'error',

--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -18,11 +18,6 @@ const config = {
     '@typescript-eslint/explicit-member-accessibility': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'error',
     // eslint-disable-next-line local/prefer-valid-rules
-    '@typescript-eslint/generic-type-naming': [
-      'error',
-      /^T([A-Z][a-zA-Z]+)$|^[A-Z]$/u.toString().slice(1, -2)
-    ],
-    // eslint-disable-next-line local/prefer-valid-rules
     '@typescript-eslint/member-naming': [
       'warn',
       { private: '^_', protected: '^_' }
@@ -30,6 +25,11 @@ const config = {
     '@typescript-eslint/naming-convention': [
       'error',
       { selector: 'typeLike', format: ['PascalCase'] },
+      {
+        selector: 'typeParameter',
+        format: ['PascalCase'],
+        custom: { match: true, regex: /^T([A-Z][a-zA-Z]+)$|^[A-Z]$/u.source }
+      },
       { selector: 'variable', format: ['camelCase', 'UPPER_CASE'] },
       { selector: 'enumMember', format: ['PascalCase', 'UPPER_CASE'] }
     ],

--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -17,6 +17,7 @@ const config = {
     '@typescript-eslint/default-param-last': 'error',
     '@typescript-eslint/explicit-member-accessibility': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'error',
+    '@typescript-eslint/interface-name-prefix': 'off',
     // eslint-disable-next-line local/prefer-valid-rules
     '@typescript-eslint/member-naming': [
       'warn',
@@ -31,7 +32,12 @@ const config = {
         custom: { match: true, regex: /^T([A-Z][a-zA-Z]+)$|^[A-Z]$/u.source }
       },
       { selector: 'variable', format: ['camelCase', 'UPPER_CASE'] },
-      { selector: 'enumMember', format: ['PascalCase', 'UPPER_CASE'] }
+      { selector: 'enumMember', format: ['PascalCase', 'UPPER_CASE'] },
+      {
+        selector: 'interface',
+        format: ['PascalCase'], // disallow "I" prefixing, but allow names like "IAM"
+        custom: { match: false, regex: /^I[A-Z][a-z]/u.source }
+      }
     ],
     '@typescript-eslint/no-dynamic-delete': 'error',
     '@typescript-eslint/no-extra-non-null-assertion': 'error',

--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -29,7 +29,8 @@ const config = {
     ],
     '@typescript-eslint/naming-convention': [
       'error',
-      { selector: 'typeLike', format: ['PascalCase'] }
+      { selector: 'typeLike', format: ['PascalCase'] },
+      { selector: 'variable', format: ['camelCase', 'UPPER_CASE'] }
     ],
     '@typescript-eslint/no-dynamic-delete': 'error',
     '@typescript-eslint/no-extra-non-null-assertion': 'error',

--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -30,7 +30,6 @@ const config = {
         format: ['PascalCase'],
         custom: { match: true, regex: /^T([A-Z][a-zA-Z]+)$|^[A-Z]$/u.source }
       },
-      { selector: 'variable', format: ['camelCase', 'UPPER_CASE'] },
       { selector: 'enumMember', format: ['PascalCase', 'UPPER_CASE'] },
       {
         selector: 'interface',

--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -37,6 +37,11 @@ const config = {
         selector: 'interface',
         format: ['PascalCase'], // disallow "I" prefixing, but allow names like "IAM"
         custom: { match: false, regex: /^I[A-Z][a-z]/u.source }
+      },
+      {
+        selector: 'parameter',
+        format: ['camelCase'],
+        leadingUnderscore: 'allow'
       }
     ],
     '@typescript-eslint/no-dynamic-delete': 'error',

--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -24,6 +24,7 @@ const config = {
         selector: 'default',
         format: ['camelCase', 'PascalCase', 'UPPER_CASE']
       },
+      { selector: 'property', format: null },
       { selector: 'typeLike', format: ['PascalCase'] },
       {
         selector: 'typeParameter',

--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -18,11 +18,6 @@ const config = {
     '@typescript-eslint/explicit-member-accessibility': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'error',
     '@typescript-eslint/interface-name-prefix': 'off',
-    // eslint-disable-next-line local/prefer-valid-rules
-    '@typescript-eslint/member-naming': [
-      'warn',
-      { private: '^_', protected: '^_' }
-    ],
     '@typescript-eslint/naming-convention': [
       'error',
       { selector: 'typeLike', format: ['PascalCase'] },
@@ -42,6 +37,24 @@ const config = {
         selector: 'parameter',
         format: ['camelCase'],
         leadingUnderscore: 'allow'
+      },
+      {
+        selector: 'memberLike',
+        modifiers: ['private'],
+        format: ['PascalCase', 'camelCase'],
+        leadingUnderscore: 'require'
+      },
+      {
+        selector: 'memberLike',
+        modifiers: ['protected'],
+        format: ['PascalCase', 'camelCase'],
+        leadingUnderscore: 'require'
+      },
+      {
+        selector: 'memberLike',
+        modifiers: ['public'],
+        format: ['PascalCase', 'camelCase'],
+        leadingUnderscore: 'forbid'
       }
     ],
     '@typescript-eslint/no-dynamic-delete': 'error',

--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -20,6 +20,10 @@ const config = {
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/naming-convention': [
       'error',
+      {
+        selector: 'default',
+        format: ['camelCase', 'PascalCase', 'UPPER_CASE']
+      },
       { selector: 'typeLike', format: ['PascalCase'] },
       {
         selector: 'typeParameter',

--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -28,8 +28,8 @@ const config = {
       { private: '^_', protected: '^_' }
     ],
     '@typescript-eslint/naming-convention': [
-      'error'
-      //
+      'error',
+      { selector: 'typeLike', format: ['PascalCase'] }
     ],
     '@typescript-eslint/no-dynamic-delete': 'error',
     '@typescript-eslint/no-extra-non-null-assertion': 'error',

--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -30,7 +30,8 @@ const config = {
     '@typescript-eslint/naming-convention': [
       'error',
       { selector: 'typeLike', format: ['PascalCase'] },
-      { selector: 'variable', format: ['camelCase', 'UPPER_CASE'] }
+      { selector: 'variable', format: ['camelCase', 'UPPER_CASE'] },
+      { selector: 'enumMember', format: ['PascalCase', 'UPPER_CASE'] }
     ],
     '@typescript-eslint/no-dynamic-delete': 'error',
     '@typescript-eslint/no-extra-non-null-assertion': 'error',


### PR DESCRIPTION
I'm pretty happy with this now - I've checked it again relm & terra, and they're both pretty sweat.

I've left `@typescript-eslint/camelcase` enabled as it'll catch enough of the camelcase to gently nudge us without leaving us out to dry if we have a third-party library that requires camelcase, since we can disable it.

closes #12 