### PR TITLE
Enable isolated modules

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -14,7 +14,7 @@ jobs:
           configFile: './package.json'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  eslint:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -48,3 +48,20 @@ jobs:
 
       - run: npm ci
       - run: npm run test
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - run: npm ci
+      - run: npm run typecheck

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,8 @@ jobs:
         run: npm ci
       - name: lint
         run: npm run lint
+      - name: typecheck
+        run: npm run typecheck
       - name: test
         run: npm run test
       - run: npm run release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   release:
-    name: release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -29,7 +28,9 @@ jobs:
         run: npm run typecheck
       - name: test
         run: npm run test
-      - run: npm run release
+
+      - name: release
+        run: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,11 @@
   },
   "prettier": "prettier-config-ackama",
   "jest": {
+    "globals": {
+      "ts-jest": {
+        "isolatedModules": true
+      }
+    },
     "moduleFileExtensions": [
       "ts",
       "tsx",


### PR DESCRIPTION
This speeds up tests by skipping type checking, which also tends to make for a nicer developer experience since you can run the tests without having to appease TypeScript.