### PR TITLE
feat: use `ignorePatterns` in configs instead of `.eslintignore`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,9 +1,0 @@
-/node_modules/
-/coverage/
-/bundle/
-/vendor/
-/dist/
-/lib/
-/out/
-!.eslintrc.js
-!.eslintplugin/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ const config = {
     './@typescript-eslint.js',
     'plugin:eslint-plugin/recommended'
   ],
+  ignorePatterns: ['!.eslintplugin/'],
   overrides: [
     { files: ['*.spec.*'], extends: ['./jest.js'] },
     {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,25 @@ Install this package:
 
 #### `.eslintignore`
 
-You can use the `.eslintignore` file used by this repo. It includes relevant files for TypeScript, Ruby, and PHP projects.
+The configurations provided in this package specify `ignorePatterns` with common
+folders to be ignored as part of best practice, meaning an `.eslintignore` file
+is not required.
+
+Projects can use this property themselves instead of an `.eslintignore` to
+ignore additional files & folders, using standard ignore-glob syntax:
+
+```js
+/** @type {import('eslint').Linter.Config} */
+const config = {
+  extends: ['ackama'],
+  ignorePatterns: ['!.myFile.js', 'test/fixtures', '!test/fixtures/**.ts']
+};
+
+module.exports = config;
+```
+
+As `ignorePatterns` is merged across all configs being extended from, you can
+use `!` to un-ignore entries.
 
 #### @typescript-eslint
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,17 @@ const config = {
     'plugin:prettier/recommended',
     'plugin:eslint-comments/recommended'
   ],
+  ignorePatterns: [
+    '!.eslintrc.js',
+    'node_modules/',
+    'coverage/',
+    'bundle/',
+    'public/',
+    'vendor/',
+    'dist/',
+    'lib/',
+    'out/'
+  ],
   rules: {
     'eslint-comments/disable-enable-pair': ['error', { allowWholeFile: true }],
     'eslint-comments/no-unused-disable': 'error',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react.js"
   ],
   "scripts": {
-    "lint": "eslint . --ignore-pattern '!.eslintrc.js' --ext js,ts",
+    "lint": "eslint . --ext js,ts",
     "release": "semantic-release -r git+ssh://git@github.com/ackama/eslint-config-ackama.git",
     "test": "jest",
     "typecheck": "tsc --noEmit"
@@ -88,7 +88,7 @@
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "eslint": ">= 6",
+    "eslint": ">= 6.7",
     "eslint-plugin-eslint-comments": ">= 3",
     "eslint-plugin-prettier": ">= 3.1",
     "prettier": ">= 1.19"


### PR DESCRIPTION
This is the special new feature, and allows us to drop `.eslintignore` completely in favor of baking it into the `.eslintrc.js` config.

It's still standard ignore syntax, just with each line represented by an item in the array.

The exciting part is that it means we can include it in the actual shared configurations, and in turn drop `.eslintignore.tt` from the rails template.