### PR TITLE
fix(@typescript-eslint): disable `method-signature-style`

### DIFF
--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -18,7 +18,6 @@ const config = {
     '@typescript-eslint/explicit-member-accessibility': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'error',
     '@typescript-eslint/interface-name-prefix': 'off',
-    '@typescript-eslint/method-signature-style': 'error',
     '@typescript-eslint/naming-convention': [
       'error',
       {


### PR DESCRIPTION
Having worked with this on for a bit, and done further research, I think for now it'll be better to have this off, as I believe it only really affects definitions that involve genetics while encouraging the opposite syntax to what is optimal in runtime code (aka classes), i.e:

```
interface Mx {
  // good
  myFunc1: () => void;
  // bad
  myFunc2(): void;
}

class Tx {
  // good
  doSomething1(): void {}
  // bad
  doSomething2: () => void;
}
```

This gets even more confusing when you start implementing interfaces:

```
interface Mx {
  sayHello: () => void;
}

class Tx implements Mx {
   sayHello(): void {}
}
```

Since the differences between using a method vs a property are subtle, I suspect a lot of people will understandably reach for a property when implementing such interfaces:

```
class Tx implements Mx {
   sayHello = () => {};
}
```