### PR TITLE
fix(javascript): group `index` with `parent` & `sibling` when ordering

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ const config = {
       {
         'alphabetize': { order: 'asc' },
         'groups': [
-          ['builtin', 'external', 'internal', 'unknown', 'index'],
-          ['parent', 'sibling']
+          ['builtin', 'external', 'internal', 'unknown'],
+          ['parent', 'sibling', 'index']
         ],
         'newlines-between': 'never'
       }


### PR DESCRIPTION
It's so rare to do an index import I didn't catch this until this afternoon :joy: