### PR TITLE
Update spec name

### DIFF
--- a/test/rules/no-deprecated-rules.spec.ts
+++ b/test/rules/no-deprecated-rules.spec.ts
@@ -131,7 +131,21 @@ ruleTester.run('no-deprecated-rules', rule, {
           data: {
             ruleId: 'newline-before-return',
             replacedBy: 'padding-line-between-statements'
-          }
+          },
+          suggestions: [
+            {
+              messageId: 'suggestReplaceWith',
+              data: { replacement: 'newline-before-return' },
+              output: dedent`
+                const rules = {
+                  'no-shadow': 'error',
+                  'padding-line-between-statements': 'error'
+                };
+
+                module.exports = { rules };
+              `
+            }
+          ]
         }
       ]
     },
@@ -156,7 +170,25 @@ ruleTester.run('no-deprecated-rules', rule, {
           data: {
             ruleId: 'newline-before-return',
             replacedBy: 'padding-line-between-statements'
-          }
+          },
+          suggestions: [
+            {
+              messageId: 'suggestReplaceWith',
+              data: { replacement: 'padding-line-between-statements' },
+              output: dedent`
+                const rules = {
+                  'padding-line-between-statements': 'error'
+                };
+
+                module.exports = {
+                  rules: {
+                    'newline-before-return': 'error',
+                    'no-shadow': 'error'
+                  }
+                };
+              `
+            }
+          ]
         },
         {
           line: 7,
@@ -165,7 +197,25 @@ ruleTester.run('no-deprecated-rules', rule, {
           data: {
             ruleId: 'newline-before-return',
             replacedBy: 'padding-line-between-statements'
-          }
+          },
+          suggestions: [
+            {
+              messageId: 'suggestReplaceWith',
+              data: { replacement: 'padding-line-between-statements' },
+              output: dedent`
+                const rules = {
+                  'newline-before-return': 'error'
+                };
+
+                module.exports = {
+                  rules: {
+                    'padding-line-between-statements': 'error',
+                    'no-shadow': 'error'
+                  }
+                };
+              `
+            }
+          ]
         }
       ]
     },
@@ -185,7 +235,20 @@ ruleTester.run('no-deprecated-rules', rule, {
           data: {
             ruleId: 'newline-before-return',
             replacedBy: 'padding-line-between-statements'
-          }
+          },
+          suggestions: [
+            {
+              messageId: 'suggestReplaceWith',
+              data: { replacement: 'padding-line-between-statements' },
+              output: dedent`
+                module.exports = {
+                  rules: {
+                    'padding-line-between-statements': 'error'
+                  }
+                };
+              `
+            }
+          ]
         }
       ]
     },
@@ -206,7 +269,21 @@ ruleTester.run('no-deprecated-rules', rule, {
           data: {
             ruleId: 'prettier/deprecated-rule',
             replacedBy: 'replacement-rule'
-          }
+          },
+          suggestions: [
+            {
+              messageId: 'suggestReplaceWith',
+              data: { replacement: 'prettier/replacement-rule' },
+              output: dedent`
+                module.exports = {
+                  plugins: ['prettier'],
+                  rules: {
+                    'prettier/replacement-rule': 'error'
+                  }
+                };
+              `
+            }
+          ]
         }
       ]
     },
@@ -232,7 +309,26 @@ ruleTester.run('no-deprecated-rules', rule, {
           data: {
             ruleId: 'newline-before-return',
             replacedBy: 'padding-line-between-statements'
-          }
+          },
+          suggestions: [
+            {
+              messageId: 'suggestReplaceWith',
+              data: { replacement: 'padding-line-between-statements' },
+              output: dedent`
+                const moreRules = {
+                  'padding-line-between-statements': 'error'
+                }
+
+                module.exports = {
+                  plugins: ['prettier'],
+                  rules: {
+                    'prettier/deprecated-rule': 'error',
+                    ...moreRules
+                  }
+                };
+              `
+            }
+          ]
         },
         {
           line: 8,
@@ -241,7 +337,26 @@ ruleTester.run('no-deprecated-rules', rule, {
           data: {
             ruleId: 'prettier/deprecated-rule',
             replacedBy: 'replacement-rule'
-          }
+          },
+          suggestions: [
+            {
+              messageId: 'suggestReplaceWith',
+              data: { replacement: 'prettier/replacement-rule' },
+              output: dedent`
+                const moreRules = {
+                  'newline-before-return': 'error'
+                }
+
+                module.exports = {
+                  plugins: ['prettier'],
+                  rules: {
+                    'prettier/replacement-rule': 'error',
+                    ...moreRules
+                  }
+                };
+              `
+            }
+          ]
         }
       ]
     },
@@ -267,7 +382,26 @@ ruleTester.run('no-deprecated-rules', rule, {
           data: {
             ruleId: 'prettier/deprecated-rule',
             replacedBy: 'replacement-rule'
-          }
+          },
+          suggestions: [
+            {
+              messageId: 'suggestReplaceWith',
+              data: { replacement: 'prettier/replacement-rule' },
+              output: dedent`
+                const moreRules = {
+                  'react/no-danger': 'error'
+                }
+
+                module.exports = {
+                  plugins: ['prettier'],
+                  rules: {
+                    'prettier/replacement-rule': 'error',
+                    ...moreRules
+                  }
+                };
+              `
+            }
+          ]
         }
       ]
     }

--- a/test/rules/no-deprecated-rules.spec.ts
+++ b/test/rules/no-deprecated-rules.spec.ts
@@ -1,10 +1,36 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { ESLintUtils, TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
 import rule from '../../.eslintplugin/no-deprecated-rules';
 
 const ruleTester = new TSESLint.RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),
   parserOptions: { sourceType: 'module' }
+});
+
+jest.mock('eslint-plugin-prettier', () => {
+  return {
+    rules: {
+      'deprecated-rule': ESLintUtils.RuleCreator(name => name)({
+        name: __filename,
+        meta: {
+          type: 'problem',
+          docs: {
+            description: 'Fake rule that is deprecated, for use in testing',
+            category: 'Best Practices',
+            recommended: 'warn'
+          },
+          deprecated: true,
+          replacedBy: ['replacement-rule'],
+          messages: {},
+          schema: []
+        },
+        defaultOptions: [],
+        create() {
+          return {};
+        }
+      })
+    }
+  };
 });
 
 ruleTester.run('no-deprecated-rules', rule, {
@@ -166,9 +192,9 @@ ruleTester.run('no-deprecated-rules', rule, {
     {
       code: dedent`
         module.exports = {
-          plugins: ['@typescript-eslint'],
+          plugins: ['prettier'],
           rules: {
-            '@typescript-eslint/camelcase': 'error'
+            'prettier/deprecated-rule': 'error'
           }
         };
       `,
@@ -178,8 +204,8 @@ ruleTester.run('no-deprecated-rules', rule, {
           column: 5,
           messageId: 'deprecatedRule',
           data: {
-            ruleId: '@typescript-eslint/camelcase',
-            replacedBy: 'naming-convention'
+            ruleId: 'prettier/deprecated-rule',
+            replacedBy: 'replacement-rule'
           }
         }
       ]
@@ -191,9 +217,9 @@ ruleTester.run('no-deprecated-rules', rule, {
         }
 
         module.exports = {
-          plugins: ['@typescript-eslint'],
+          plugins: ['prettier'],
           rules: {
-            '@typescript-eslint/camelcase': 'error',
+            'prettier/deprecated-rule': 'error',
             ...moreRules
           }
         };
@@ -213,8 +239,8 @@ ruleTester.run('no-deprecated-rules', rule, {
           column: 5,
           messageId: 'deprecatedRule',
           data: {
-            ruleId: '@typescript-eslint/camelcase',
-            replacedBy: 'naming-convention'
+            ruleId: 'prettier/deprecated-rule',
+            replacedBy: 'replacement-rule'
           }
         }
       ]
@@ -226,9 +252,9 @@ ruleTester.run('no-deprecated-rules', rule, {
         }
 
         module.exports = {
-          plugins: ['@typescript-eslint'],
+          plugins: ['prettier'],
           rules: {
-            '@typescript-eslint/camelcase': 'error',
+            'prettier/deprecated-rule': 'error',
             ...moreRules
           }
         };
@@ -239,8 +265,8 @@ ruleTester.run('no-deprecated-rules', rule, {
           column: 5,
           messageId: 'deprecatedRule',
           data: {
-            ruleId: '@typescript-eslint/camelcase',
-            replacedBy: 'naming-convention'
+            ruleId: 'prettier/deprecated-rule',
+            replacedBy: 'replacement-rule'
           }
         }
       ]

--- a/test/rules/no-deprecated-rules.spec.ts
+++ b/test/rules/no-deprecated-rules.spec.ts
@@ -7,7 +7,7 @@ const ruleTester = new TSESLint.RuleTester({
   parserOptions: { sourceType: 'module' }
 });
 
-ruleTester.run('prefer-no-deprecated-rules', rule, {
+ruleTester.run('no-deprecated-rules', rule, {
   valid: [
     dedent`
       module.exports = {


### PR DESCRIPTION
Annoyingly I didn't rename the spec file when I renamed the rule :/

Also implemented suggestions to make things easier (saves me having to copy and paste the replacement names for deprecated rules).

I also realised that the tests for this were dependent on the actual package versions being used, meaning they'd become invalid when we updated - I've replaced them with a mock that returns a fake eslint plugin with a deprecated rule.

This should be applied to the tests for `prefer-valid-rules` as well at some point, but I'll do that later.