### PR TITLE
Enable `exceptAfterSingleLine` option for `lines-between-class-members`

### DIFF
--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -16,7 +16,11 @@ const config = {
     '@typescript-eslint/explicit-member-accessibility': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'error',
     '@typescript-eslint/interface-name-prefix': 'off',
-    '@typescript-eslint/lines-between-class-members': 'error',
+    '@typescript-eslint/lines-between-class-members': [
+      'error',
+      'always',
+      { exceptAfterSingleLine: true }
+    ],
     '@typescript-eslint/naming-convention': [
       'error',
       {

--- a/index.js
+++ b/index.js
@@ -48,7 +48,11 @@ const config = {
     'grouped-accessor-pairs': ['error', 'getBeforeSet'],
     'guard-for-in': 'error',
     'init-declarations': 'error',
-    'lines-between-class-members': 'error',
+    'lines-between-class-members': [
+      'error',
+      'always',
+      { exceptAfterSingleLine: true }
+    ],
     'max-classes-per-file': ['error', 1],
     'max-statements-per-line': ['error', { max: 1 }],
     'new-cap': ['error', { capIsNewExceptions: ['ESLintUtils.RuleCreator'] }],


### PR DESCRIPTION
We actually want this left on, for class members:

```
class Mx {
  // no lines required between these
  p1: string;
  p2: string;

  // these require newlines in between
  m1() {
    //
  }
  
  m2() {
    //
  }
}
```

Technically this option lets you do `get g1() { return <value> }` which we don't want, but `prettier` prevents you from doing that.