### PR TITLE
fix: specify `eslint-plugin-import` as `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "eslint": ">= 6.7",
     "eslint-plugin-eslint-comments": ">= 3",
     "eslint-plugin-prettier": ">= 3.1",
+    "eslint-plugin-import": ">= 2.21",
     "prettier": ">= 1.19"
   },
   "release": {


### PR DESCRIPTION
This should be automated & tested for, but it's smallish fry as eslint will error without it anyway - I don't think this would even break yarn pnp 🤔 

The reason I'm doing it is that it's used to dynamically generate the `npm install --save-dev` line in the README.