### PR TITLE
fix: don't ignore parent dirs, to allow for negation globs

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,14 +13,14 @@ const config = {
   ],
   ignorePatterns: [
     '!.eslintrc.js',
-    'node_modules/',
-    'coverage/',
-    'bundle/',
-    'public/',
-    'vendor/',
-    'dist/',
-    'lib/',
-    'out/'
+    'node_modules/*',
+    'coverage/*',
+    'bundle/*',
+    'public/*',
+    'vendor/*',
+    'dist/*',
+    'lib/*',
+    'out/*'
   ],
   rules: {
     'eslint-comments/disable-enable-pair': ['error', { allowWholeFile: true }],


### PR DESCRIPTION
Per https://github.com/eslint/eslint/issues/13560#issuecomment-672757418: 

> It is not possible to re-include a file if a parent directory of that file is excluded. Git doesn’t list excluded directories for performance reasons, so any patterns on contained files have no effect, no matter where they are defined.

Currently this prevents us from excluding specific files, i.e `!public/wp-admin`.