### PR TITLE
fix(@typescript-eslint): remove `interface-name-prefix` rule

### DIFF
--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -15,7 +15,6 @@ const config = {
     '@typescript-eslint/default-param-last': 'error',
     '@typescript-eslint/explicit-member-accessibility': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'error',
-    '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/lines-between-class-members': [
       'error',
       'always',


### PR DESCRIPTION
I missed this one when upgrading to v4