### PR TITLE
ci: add `renovate` to regenerate lock file

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["config:base"],
+  "lockFileMaintenance": { "enabled": true },
+  "postUpdateOptions": ["npmDedupe"]
+}


### PR DESCRIPTION
I think it'd be good to regenerate the lockfile on a ~monthly basis, just so we're up to date and in case anything changes in minor versions that we should know about.

This should hopefully do that, while maintaining semantic versioning constraints.

closes #62 