### PR TITLE
ci: update `renovate` config to not pin dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": ["config:base"],
   "lockFileMaintenance": { "enabled": true },
+  "rangeStrategy": "replace",
   "postUpdateOptions": ["npmDedupe"]
 }


### PR DESCRIPTION
I figured this would happen - oh well.