### PR TITLE
feat(react): make `jsx-no-bind` `warn` instead of `error`

### DIFF
--- a/react.js
+++ b/react.js
@@ -45,7 +45,7 @@ const config = {
     'react/jsx-filename-extension': ['warn', { extensions: ['.tsx', '.jsx'] }],
     'react/jsx-fragments': 'error',
     'react/jsx-handler-names': 'error',
-    'react/jsx-no-bind': 'error',
+    'react/jsx-no-bind': 'warn',
     'react/jsx-no-script-url': 'error',
     'react/jsx-no-useless-fragment': 'error',
     'react/jsx-pascal-case': 'error',


### PR DESCRIPTION
Me & @mischa-s have been talking and decided now that hooks are the mainstream way of doing react it makes less sense to have this at `error` level.