### PR TITLE
fix(flowtype): switch to `@babel/eslint-parser`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Below is a complete list of the configs provided, and their dependencies:
   - `@typescript-eslint/parser`
 - `ackama/flowtype`
   - `eslint-plugin-flowtype`
-  - `babel-eslint`
+  - `@babel/eslint-parser`
 - `ackama/jest`
   - `eslint-plugin-jest`
   - `eslint-plugin-jest-formatting`

--- a/flowtype.js
+++ b/flowtype.js
@@ -1,6 +1,6 @@
 /** @type {import('eslint').Linter.Config} */
 const config = {
-  parser: 'babel-eslint',
+  parser: '@babel/eslint-parser',
   plugins: ['flowtype'],
   extends: ['plugin:flowtype/recommended', 'prettier/flowtype'],
   rules: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,31 @@
         }
       }
     },
+    "@babel/eslint-parser": {
+      "version": "7.13.14",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.13.14.tgz",
+      "integrity": "sha512-I0HweR36D73Ibn/FfrRDMKlMqJHFwidIUgYdMpH+aXYuQC+waq59YaJ6t9e9N36axJ82v1jR041wwqDrDXEwRA==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "^5.1.0",
+        "eslint-visitor-keys": "^1.3.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "@babel/generator": {
       "version": "7.13.16",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.16.tgz",
@@ -1846,28 +1871,6 @@
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
       "dev": true
-    },
-    "babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
-      }
     },
     "babel-jest": {
       "version": "26.6.3",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-config-prettier": "^6.10.0"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.13.14",
     "@commitlint/cli": "^12.0.0",
     "@commitlint/config-conventional": "^12.0.0",
     "@semantic-release/changelog": "^5.0.1",
@@ -64,7 +65,6 @@
     "@types/node": "^14.14.1",
     "@typescript-eslint/eslint-plugin": "^4.5.0",
     "@typescript-eslint/parser": "^4.5.0",
-    "babel-eslint": "^10.1.0",
     "eslint": "^7.21.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-eslint-config": "^2.0.0",


### PR DESCRIPTION
Technically this should be a breaking change, but we're not actually using flow anywhere and we're not going to be doing a new major anytime soon so better to just get it changed now 🤷 