### PR TITLE
fix: bring quote props rule inline with prettier config

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,6 +181,7 @@ const config = {
     'prefer-rest-params': 'error',
     'prefer-spread': 'error',
     'prefer-template': 'warn',
+    'quote-props': ['error', 'consistent-as-needed'],
     'radix': ['error', 'as-needed'],
     'require-await': 'off', // never
     'require-unicode-regexp': 'error',


### PR DESCRIPTION
In order to get prettier and eslint not conflicting over quote-props; 

https://github.com/ackama/prettier-config-ackama/blob/master/.prettierrc.json

The prettierrc specifies 
`
"quoteProps": "consistent"
`

but the default eslint rule for quote-props is "always", which conflicts with the specification of the prettierrc. In order to match the suggested code style in prettierrc, we need to update the eslint to the matching config of 'consistent-as-needed'