### PR TITLE
feat(jest): use enhanced version of `unbound-method` rule

### DIFF
--- a/jest.js
+++ b/jest.js
@@ -7,6 +7,7 @@ const config = {
     'plugin:jest-formatting/recommended'
   ],
   rules: {
+    '@typescript-eslint/unbound-method': 'off',
     'jest/consistent-test-it': 'error',
     'jest/expect-expect': [
       'error',
@@ -38,6 +39,7 @@ const config = {
     'jest/prefer-todo': 'error',
     'jest/require-to-throw-message': 'error',
     'jest/require-top-level-describe': 'error',
+    'jest/unbound-method': 'error',
     'jest/valid-title': 'error'
   }
 };

--- a/package.json
+++ b/package.json
@@ -92,8 +92,14 @@
     "eslint-plugin-eslint-comments": ">= 3",
     "eslint-plugin-prettier": ">= 3.1",
     "eslint-plugin-import": ">= 2.21",
+    "eslint-plugin-jest": ">= 24.3",
     "eslint-plugin-node": ">= 2.21",
     "prettier": ">= 2.0"
+  },
+  "peerDependenciesMeta": {
+    "eslint-plugin-jest": {
+      "optional": true
+    }
   },
   "release": {
     "branches": [


### PR DESCRIPTION
I implemented this rule a while back, but wanted to wait before adding it here in case any bugs showed up.

The rule itself is a light wrapper around `@typescript-eslint/unbound-method` that only calls the underlying rule if the AST node being checked *isn't* a call to one of the `expect` matchers that takes a function, i.e. `toHaveBeenCalled` & co, as those methods don't require the argument to be bound since they're not actually calling the function (they're checking properties on it).

For example:

```
it('sends the buffered messages to the Slack webhook', async () => {
  const notifier = new Notifier('https://example.com/webhook');

  notifier.bufferMessage(message);

  await notifier.sendBufferedMessages();

  // eslint-disable-next-line @typescript-eslint/unbound-method
  expect(fakeIncomingWebhook.prototype.send).toHaveBeenCalledWith({
    text: message
  });
});
```

This rule lets us remove the `eslint-disable-next-line`, while still having all other test code checked for unbound methods 🎉 

In order to make it easier to include this rule in configs, it silently fails if the base rule cannot be imported for some reason, aka if you're on a Javascript project that uses `jest` but not `typescript` - this means we can safely include it here instead of having to maintain a separate `jest-and-typescript` config just for this.

----

I've also included specifying `eslint-plugin-jest` as an optional peer dependency, which should be fine (and tbh we should be doing this for all our other plugin dependencies), but if it turns out to cause trouble (such as on older projects) then it can be reverted as it's a "technically more correct but not strictly required" sort of thing.