### PR TITLE
chore: remove unneeded `eslint-plugin` plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,17 +9,8 @@ const config = {
     sourceType: 'module',
     ecmaVersion: 2019
   },
-  plugins: [
-    '@typescript-eslint/eslint-plugin',
-    'eslint-config',
-    'eslint-plugin'
-  ],
-  extends: [
-    './index.js',
-    './@typescript-eslint.js',
-    'plugin:eslint-config/rc',
-    'plugin:eslint-plugin/recommended'
-  ],
+  plugins: ['@typescript-eslint/eslint-plugin', 'eslint-config'],
+  extends: ['./index.js', './@typescript-eslint.js', 'plugin:eslint-config/rc'],
   ignorePatterns: ['!.eslintplugin/'],
   overrides: [
     { files: ['*.spec.*'], extends: ['./jest.js'] },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3067,32 +3067,6 @@
         "require-relative": "^0.8.7"
       }
     },
-    "eslint-plugin-eslint-plugin": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-3.6.1.tgz",
-      "integrity": "sha512-SOE0aoS2+lvtcEbJmy98gEKaxcpkQdxDtqvqE0VQSiGEFme8yTNjpLAjMqPDmmj8KGTwIFd+cYnVykz+9HAIiw==",
-      "dev": true,
-      "requires": {
-        "eslint-utils": "^2.1.0"
-      },
-      "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
-      }
-    },
     "eslint-plugin-flowtype": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-6.0.1.tgz",
@@ -6253,7 +6227,8 @@
           "dependencies": {
             "ansi-regex": {
               "version": "5.0.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+              "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
               "dev": true
             },
             "is-fullwidth-code-point": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "eslint": "^7.21.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-eslint-config": "^2.0.0",
-    "eslint-plugin-eslint-plugin": "^3.0.0",
     "eslint-plugin-flowtype": "^6.0.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.0",


### PR DESCRIPTION
It's for eslint plugins, so isn't needed now that we don't have a local
plugin