### PR TITLE
docs: list parser first in config requirements in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ Below is a complete list of the configs provided, and their dependencies:
   - `eslint-plugin-import`
   - `eslint-plugin-node`
 - `ackama/@typescript-eslint`
-  - `@typescript-eslint/eslint-plugin`
   - `@typescript-eslint/parser`
+  - `@typescript-eslint/eslint-plugin`
 - `ackama/flowtype`
-  - `eslint-plugin-flowtype`
   - `@babel/eslint-parser`
+  - `eslint-plugin-flowtype`
 - `ackama/jest`
   - `eslint-plugin-jest`
   - `eslint-plugin-jest-formatting`

--- a/tools/generate-configs-list.ts
+++ b/tools/generate-configs-list.ts
@@ -78,7 +78,7 @@ const determineConfigDependencies = (configName: string): string[] => {
   const deps = configFile.plugins.map(determinePluginPackageName);
 
   if (configFile.parser) {
-    deps.push(configFile.parser);
+    deps.unshift(configFile.parser);
   }
 
   return deps;


### PR DESCRIPTION
It doesn't matter much, but I think it's a bit nicer to have `parser` first since it's always a single package and tends to appear at the top of configs anyway.