### PR TITLE
ci: don't test against eslint v6

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        eslint: [6, 7]
+        eslint: [7]
         os: [ubuntu-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
We technically dropped support for it a while ago, but kept it in our CI
since it was still passing; now however v4 of `eslint-plugin-prettier`
requires v7 or above, so our CI is failing testing on v6

This allows landing #161