### PR TITLE
chore: reduce renovate noise

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,10 @@
 {
   "extends": ["config:base"],
-  "lockFileMaintenance": { "enabled": true, "automerge": true },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "schedule": ["after 1am and before 2am on monday"]
+  },
   "rangeStrategy": "replace",
   "postUpdateOptions": ["npmDedupe"]
 }


### PR DESCRIPTION
This should hopefully reduce the amount of noise we get from Renovate when it tries to refresh the lockfile and for _some reason_ moves a bunch of dependencies literally back and forth between two places on the tree 🙄 

Specifically, this restricts it to being able to run between 1 hour of time, rather than ~5 hours (which is the default)