### PR TITLE
fix(jest): switch to using `no-conditional-in-test` rule

### DIFF
--- a/jest.js
+++ b/jest.js
@@ -15,8 +15,8 @@ const config = {
       { assertFunctionNames: ['expect'] }
     ],
     'jest/no-conditional-expect': 'error',
+    'jest/no-conditional-in-test': 'error',
     'jest/no-deprecated-functions': 'error',
-    'jest/no-if': 'error',
     'jest/no-large-snapshots': 'warn',
     'jest/no-restricted-matchers': [
       'error',

--- a/test/configs.spec.ts
+++ b/test/configs.spec.ts
@@ -134,9 +134,9 @@ describe('for each config file', () => {
         },
         // make all enabled rules warn, since misconfigured rules will create errors
         rules: Object.fromEntries(
-          Object.entries(config.rules).map(([name, value]) => [
+          Object.entries(config.rules).map(([name, value = 'warn']) => [
             name,
-            makeEnabledRulesWarn(value ?? 'warn')
+            makeEnabledRulesWarn(value)
           ])
         )
       };


### PR DESCRIPTION
This is mainly to get #225 released, since `npm` v7+ doesn't let us install v26 without it.

I deprecated `no-if` in favor of `no-conditional-in-test`, as it's an improved version of the rule that checks for other kinds of conditional statements like switches and ternarys