### PR TITLE
fix: explicitly enable `curly` in configs that include `prettier`

### DIFF
--- a/@typescript-eslint.js
+++ b/@typescript-eslint.js
@@ -9,6 +9,10 @@ const config = {
     'plugin:prettier/recommended'
   ],
   rules: {
+    // explicitly (re)enable this as it's disabled by eslint-config-prettier
+    // and its likely our standard JS config will be used alongside this one
+    'curly': 'error',
+
     '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
     '@typescript-eslint/default-param-last': 'error',
     '@typescript-eslint/explicit-member-accessibility': 'error',

--- a/flowtype.js
+++ b/flowtype.js
@@ -4,6 +4,10 @@ const config = {
   plugins: ['flowtype', 'prettier'],
   extends: ['plugin:flowtype/recommended', 'plugin:prettier/recommended'],
   rules: {
+    // explicitly (re)enable this as it's disabled by eslint-config-prettier
+    // and its likely our standard JS config will be used alongside this one
+    'curly': 'error',
+
     'flowtype/array-style-complex-type': ['error', 'verbose'],
     'flowtype/array-style-simple-type': ['error', 'shorthand'],
     'flowtype/arrow-parens': ['error', 'as-needed'],

--- a/react.js
+++ b/react.js
@@ -30,6 +30,10 @@ const config = {
     }
   ],
   rules: {
+    // explicitly (re)enable this as it's disabled by eslint-config-prettier
+    // and its likely our standard JS config will be used alongside this one
+    'curly': 'error',
+
     'react/button-has-type': 'warn',
     'react/default-props-match-prop-types': 'warn',
     'react/display-name': 'off', // todo: re-look into

--- a/test/configs.spec.ts
+++ b/test/configs.spec.ts
@@ -237,6 +237,12 @@ describe('for each config file', () => {
         expect(config.plugins).toContainEqual('prettier');
         expect(config.extends).toContainEqual('plugin:prettier/recommended');
       });
+
+      it('should explicitly set curly', () => {
+        expect.hasAssertions();
+
+        expect(config.rules).toHaveProperty('curly', 'error');
+      });
     }
   });
 });


### PR DESCRIPTION
`curly` is disabled by `eslint-config-prettier` as some of its configuration can conflict with Prettier; we enable it in our standard config in a way that is compatible but it's not in our tech-specific configs that do extend from `eslint-config-prettier` - since these configs are meant to come after our standard config, `curly` ends up getting completely disabled.

Because of how rules and configs currently work the main way to address this is by explicitly enabling the rule in each config - even though technically this rule isn't specific to the technologies each config is about, it's completely autofixable and I think it's reasonable to assume they'll be used with our standard config so I've gone with that.

This should not be needed once ESLint moves to using flat configs because we can just filter this rule out when importing `eslint-config-prettier`.