### PR TITLE
chore: remove codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @ackama/maximum-sass


### PR DESCRIPTION
Our structure has changed so this group no longer exists