### PR TITLE
chore: update deprecated `ts-jest` config

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,6 @@
   },
   "prettier": "prettier-config-ackama",
   "jest": {
-    "globals": {
-      "ts-jest": {
-        "isolatedModules": true
-      }
-    },
     "moduleFileExtensions": [
       "ts",
       "tsx",
@@ -47,7 +42,12 @@
     "restoreMocks": true,
     "testEnvironment": "node",
     "transform": {
-      "\\.tsx?": "ts-jest"
+      "\\.tsx?": [
+        "ts-jest",
+        {
+          "isolatedModules": true
+        }
+      ]
     }
   },
   "dependencies": {


### PR DESCRIPTION
```
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
}
```