### PR TITLE
fix: allow v7 of `@typescript-eslint` and v28 of `eslint-plugin-jest`

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -53,12 +53,17 @@ jobs:
     permissions:
       contents: read # to fetch code (actions/checkout)
     # prettier-ignore
-    name: Lint on ${{ matrix.os }} with eslint v${{ matrix.eslint }}, using Node.js LTS
+    name: Lint on ${{ matrix.os }} with eslint v${{ matrix.eslint }}, @typescript-eslint v${{ matrix.typescript-eslint }}, eslint-plugin-jest v${{ matrix.jest-eslint }}, and using Node.js LTS
     strategy:
       fail-fast: false
       matrix:
         eslint: [7, 8]
+        typescript-eslint: [6, 7]
+        jest-eslint: [27, 28]
         os: [ubuntu-latest, macOS-latest]
+        exclude:
+          - eslint: 7
+            typescript-eslint: 7
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -70,7 +75,8 @@ jobs:
           cache: npm
 
       - run: npm ci
-      - run: npm install eslint@${{ matrix.eslint }} --no-fund
+      # prettier-ignore
+      - run: npm install eslint@${{ matrix.eslint }} @typescript-eslint/parser@${{ matrix.typescript-eslint }} @typescript-eslint/eslint-plugin@${{ matrix.typescript-eslint }} eslint-plugin-jest@${{ matrix.jest-eslint }} --no-fund
       - run: npm run lint
   test:
     permissions:
@@ -112,3 +118,4 @@ jobs:
 
       - run: npm ci
       - run: npm run typecheck
+

--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
   },
   "peerDependencies": {
     "@babel/eslint-parser": "^7.0.0",
-    "@typescript-eslint/eslint-plugin": "^6.0.0",
-    "@typescript-eslint/parser": "^6.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0 || ^7.0.0",
+    "@typescript-eslint/parser": "^6.0.0 || ^7.0.0",
     "eslint": ">= 7.0",
     "eslint-plugin-eslint-comments": ">= 3",
     "eslint-plugin-flowtype": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "eslint-plugin-eslint-comments": ">= 3",
     "eslint-plugin-flowtype": "^8.0.0",
     "eslint-plugin-import": ">= 2.21",
-    "eslint-plugin-jest": "^27.0.0",
+    "eslint-plugin-jest": "^27.0.0 || ^28.0.0",
     "eslint-plugin-jest-formatting": "^3.0.0",
     "eslint-plugin-jsx-a11y": "^6.0.0",
     "eslint-plugin-node": ">= 2.21",


### PR DESCRIPTION
We're compatible with both of these versions:
  - `@typescript-eslint` v7 is just dropping Node versions to align with ESLint v8/v9, to make it easier for the v8 major
  - `eslint-plugin-jest` v28 is small, dropping some Node versions and removing a couple of deprecated things that we never used

For now I'm just making the smallest change possible to unblock some other unrelated work that involves NPM - I'm going to followup later with a bigger update which will include dropping support for the older versions.