### PR TITLE
chore: improve logic for determining package name for scoped plugins

### DIFF
--- a/test/configs.spec.ts
+++ b/test/configs.spec.ts
@@ -20,9 +20,6 @@ const configFiles = fs
  * Generally this is done by returning the plugin name with `eslint-plugin-`
  * appended to it (if the name does not already start with that string).
  *
- * Scoped plugins must be explicitly checked for to handle properly;
- * Currently the `@typescript-eslint` is the only supported scoped plugin.
- *
  * @param {string} plugin
  *
  * @return {string}
@@ -32,8 +29,16 @@ const determinePluginPackageName = (plugin: string): string => {
     return plugin;
   }
 
-  if (plugin === '@typescript-eslint') {
-    return `${plugin}/eslint-plugin`;
+  if (plugin.startsWith('@')) {
+    const [scope, name] = plugin.split('/');
+
+    let packageName = `${scope}/eslint-plugin`;
+
+    if (name) {
+      packageName += `-${name}`;
+    }
+
+    return packageName;
   }
 
   return `eslint-plugin-${plugin}`;

--- a/tools/generate-configs-list.ts
+++ b/tools/generate-configs-list.ts
@@ -45,9 +45,6 @@ const requireConfig = (config: string): Required<ESLint.Linter.Config> => {
  * Generally this is done by returning the plugin name with `eslint-plugin-`
  * appended to it (if the name does not already start with that string).
  *
- * Scoped plugins must be explicitly checked for to handle properly;
- * Currently the `@typescript-eslint` is the only supported scoped plugin.
- *
  * @param {string} plugin
  *
  * @return {string}
@@ -57,8 +54,16 @@ const determinePluginPackageName = (plugin: string): string => {
     return plugin;
   }
 
-  if (plugin === '@typescript-eslint') {
-    return `${plugin}/eslint-plugin`;
+  if (plugin.startsWith('@')) {
+    const [scope, name] = plugin.split('/');
+
+    let packageName = `${scope}/eslint-plugin`;
+
+    if (name) {
+      packageName += `-${name}`;
+    }
+
+    return packageName;
   }
 
   return `eslint-plugin-${plugin}`;


### PR DESCRIPTION
This should mean less thinking as we're going to start depending on more scoped packages soon as part of upgrading to ESLint v9 such as `@eslint-community/eslint-plugin-eslint-comments` and `@stylistic/eslint-plugin-{js,ts,react}`