### PR TITLE
chore: sort `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,19 @@
     ]
   },
   "prettier": "prettier-config-ackama",
+  "release": {
+    "branches": [
+      "main"
+    ],
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/changelog",
+      "@semantic-release/npm",
+      "@semantic-release/git",
+      "@semantic-release/github"
+    ]
+  },
   "jest": {
     "moduleFileExtensions": [
       "ts",
@@ -134,18 +147,5 @@
     "eslint-plugin-react-hooks": {
       "optional": true
     }
-  },
-  "release": {
-    "branches": [
-      "main"
-    ],
-    "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
-      "@semantic-release/changelog",
-      "@semantic-release/npm",
-      "@semantic-release/git",
-      "@semantic-release/github"
-    ]
   }
 }


### PR DESCRIPTION
The latest version of `sort-package-json` now likes `release` here