### PR TITLE
fix: let `prettier` handle `quote-props`

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,7 +183,6 @@ const config = {
     'prefer-rest-params': 'error',
     'prefer-spread': 'error',
     'prefer-template': 'warn',
-    'quote-props': ['error', 'consistent-as-needed'],
     'radix': ['error', 'as-needed'],
     'require-await': 'off', // never
     'require-unicode-regexp': 'error',


### PR DESCRIPTION
This reverts #101 which was never actually needed - for the most part having it configured is harmless since it matches our prettier config which in theory all of our codebases use, but if we ever have one that has a different [quote props](https://prettier.io/docs/en/options.html#quote-props) setting (e.g. due to an inherited codebase) then you have to deal with this.

Removing it's configuration just means one less place to stub your toe