### PR TITLE
feat: allow `eslint-plugin-react-hooks` v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "eslint-plugin-node": ">= 2.21",
         "eslint-plugin-prettier": ">= 3.1",
         "eslint-plugin-react": "^7.0.0",
-        "eslint-plugin-react-hooks": "^4.0.0",
+        "eslint-plugin-react-hooks": "^4.0.0 || ^5.0.0",
         "prettier": ">= 2.0"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "eslint-plugin-node": ">= 2.21",
     "eslint-plugin-prettier": ">= 3.1",
     "eslint-plugin-react": "^7.0.0",
-    "eslint-plugin-react-hooks": "^4.0.0",
+    "eslint-plugin-react-hooks": "^4.0.0 || ^5.0.0",
     "prettier": ">= 2.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
This version adds support for ESLint v9 while being backwards compatible for us so we can allow both v4 and v5 at the same time.

[changelog is here](https://github.com/facebook/react/releases/tag/eslint-plugin-react-hooks%405.0.0)