### PR TITLE
test: remove unneeded module augmentation

### DIFF
--- a/test/configs.spec.ts
+++ b/test/configs.spec.ts
@@ -55,16 +55,6 @@ const requireConfig = (
   ...(require(config) as ESLint.Linter.Config)
 });
 
-// todo: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56545
-declare module 'eslint' {
-  // eslint-disable-next-line @typescript-eslint/no-shadow
-  namespace ESLint {
-    interface LintResult {
-      fatalErrorCount: number;
-    }
-  }
-}
-
 describe('package.json', () => {
   it('includes every config file', () => {
     expect.hasAssertions();


### PR DESCRIPTION
My pull request to `@types/eslint` adding this property got merged and released years ago so we've not needed this in a while 😅 