### PR TITLE
feat: make all rules `error` instead of `warn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ passing it the name of your custom hook via its `additionalHooks` option:
 ```json
 {
   "rules": {
-    "react-hooks/exhaustive-deps": ["warn", { "additionalHooks": "useHook" }]
+    "react-hooks/exhaustive-deps": ["error", { "additionalHooks": "useHook" }]
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -27,17 +27,17 @@ const generateConfig = () => {
         'newlines-between': 'never'
       }
     ],
-    'n/callback-return': 'warn',
+    'n/callback-return': 'error',
     'n/global-require': 'error',
     'n/no-deprecated-api': 'error',
     'n/no-mixed-requires': 'error',
     'n/no-new-require': 'error',
     'n/no-path-concat': 'error',
     'n/no-process-exit': 'error',
-    'n/no-sync': 'warn',
+    'n/no-sync': 'error',
     'accessor-pairs': ['error', { enforceForClassMembers: true }],
     'array-callback-return': 'error',
-    'block-scoped-var': 'warn',
+    'block-scoped-var': 'error',
     'camelcase': ['error', { allow: ['child_process'] }],
     'consistent-return': 'error',
     'consistent-this': 'error',
@@ -57,7 +57,7 @@ const generateConfig = () => {
     ],
     'max-classes-per-file': ['error', 1],
     'new-cap': ['error', { capIsNewExceptions: ['ESLintUtils.RuleCreator'] }],
-    'no-alert': 'warn',
+    'no-alert': 'error',
     'no-array-constructor': 'error',
     'no-await-in-loop': 'error',
     'no-bitwise': 'error',
@@ -98,7 +98,7 @@ const generateConfig = () => {
     'no-self-compare': 'error',
     'no-sequences': 'error',
     'no-setter-return': 'error',
-    'no-shadow': 'warn',
+    'no-shadow': 'error',
     'no-template-curly-in-string': 'error',
     'no-throw-literal': 'error',
     'no-undef-init': 'error',
@@ -147,7 +147,7 @@ const generateConfig = () => {
         next: 'directive'
       }
     ],
-    'prefer-arrow-callback': 'warn',
+    'prefer-arrow-callback': 'error',
     'prefer-const': 'error',
     'prefer-destructuring': [
       'error',
@@ -163,14 +163,14 @@ const generateConfig = () => {
     'prefer-regex-literals': 'error',
     'prefer-rest-params': 'error',
     'prefer-spread': 'error',
-    'prefer-template': 'warn',
+    'prefer-template': 'error',
     'radix': ['error', 'as-needed'],
     'require-await': 'off', // never
     'require-unicode-regexp': 'error',
     'sort-imports': ['error', { ignoreDeclarationSort: true }],
     'sort-vars': 'error',
     '@stylistic/js/spaced-comment': [
-      'warn',
+      'error',
       'always',
       {
         markers: ['=', '#region'],

--- a/jest.js
+++ b/jest.js
@@ -36,7 +36,7 @@ const generateConfig = () => {
     'jest/no-conditional-expect': 'error',
     'jest/no-conditional-in-test': 'error',
     'jest/no-deprecated-functions': 'error',
-    'jest/no-large-snapshots': 'warn',
+    'jest/no-large-snapshots': 'error',
     'jest/no-restricted-matchers': [
       'error',
       banMatchers({
@@ -50,7 +50,7 @@ const generateConfig = () => {
     'jest/no-test-return-statement': 'error',
     'jest/prefer-called-with': 'error',
     // you can disable this if you use a `beforeEach` setup script,
-    'jest/prefer-expect-assertions': 'warn',
+    'jest/prefer-expect-assertions': 'error',
     'jest/prefer-expect-resolves': 'error',
     'jest/prefer-hooks-on-top': 'error',
     'jest/prefer-lowercase-title': ['error', { ignoreTopLevelDescribe: true }],

--- a/react.js
+++ b/react.js
@@ -12,13 +12,13 @@ const generateConfig = () => {
 
     // todo: react-hooks does not export a flat config (yet)
     'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'warn',
+    'react-hooks/exhaustive-deps': 'error',
 
-    'react/button-has-type': 'warn',
-    'react/default-props-match-prop-types': 'warn',
+    'react/button-has-type': 'error',
+    'react/default-props-match-prop-types': 'error',
     'react/display-name': 'off', // todo: re-look into
     'react/forbid-foreign-prop-types': 'error',
-    'react/forbid-prop-types': 'warn',
+    'react/forbid-prop-types': 'error',
 
     'react/function-component-definition': [
       'error',
@@ -27,37 +27,37 @@ const generateConfig = () => {
         unnamedComponents: 'arrow-function'
       }
     ],
-    'react/jsx-boolean-value': 'warn',
-    'react/jsx-curly-brace-presence': 'warn',
-    'react/jsx-filename-extension': ['warn', { extensions: ['.tsx', '.jsx'] }],
+    'react/jsx-boolean-value': 'error',
+    'react/jsx-curly-brace-presence': 'error',
+    'react/jsx-filename-extension': ['error', { extensions: ['.tsx', '.jsx'] }],
     'react/jsx-fragments': 'error',
     'react/jsx-handler-names': 'error',
     'react/jsx-no-script-url': 'error',
     'react/jsx-no-useless-fragment': 'error',
     'react/jsx-pascal-case': 'error',
     'react/no-access-state-in-setstate': 'error',
-    'react/no-array-index-key': 'warn',
+    'react/no-array-index-key': 'error',
     'react/no-danger': 'error',
     'react/no-did-mount-set-state': 'error',
     'react/no-did-update-set-state': 'error',
-    'react/no-multi-comp': ['warn', { ignoreStateless: true }],
+    'react/no-multi-comp': ['error', { ignoreStateless: true }],
     'react/no-redundant-should-component-update': 'error',
     'react/no-this-in-sfc': 'error',
     'react/no-typos': 'error',
     'react/no-unused-prop-types': 'error',
-    'react/no-unused-state': 'warn',
-    'react/no-will-update-set-state': 'warn',
+    'react/no-unused-state': 'error',
+    'react/no-will-update-set-state': 'error',
     'react/prefer-es6-class': 'error',
     'react/prefer-read-only-props': 'error',
-    'react/prefer-stateless-function': 'warn',
+    'react/prefer-stateless-function': 'error',
     'react/require-default-props': [
       'error',
       { ignoreFunctionalComponents: true }
     ],
-    'react/self-closing-comp': 'warn',
+    'react/self-closing-comp': 'error',
     'react/state-in-constructor': ['error', 'never'],
-    'react/style-prop-object': 'warn',
-    'react/void-dom-elements-no-children': 'warn'
+    'react/style-prop-object': 'error',
+    'react/void-dom-elements-no-children': 'error'
   };
 
   if (process.env.ESLINT_USE_FLAT_CONFIG !== 'false') {

--- a/typescript.js
+++ b/typescript.js
@@ -85,7 +85,7 @@ const generateConfig = () => {
       }
     ],
     '@typescript-eslint/no-redeclare': 'error',
-    '@typescript-eslint/no-shadow': 'warn',
+    '@typescript-eslint/no-shadow': 'error',
     '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
     '@typescript-eslint/no-unnecessary-condition': 'error',
     '@typescript-eslint/no-unnecessary-qualifier': 'error',
@@ -97,13 +97,13 @@ const generateConfig = () => {
     ],
     '@typescript-eslint/no-useless-constructor': 'error',
     '@typescript-eslint/parameter-properties': 'error',
-    '@typescript-eslint/prefer-readonly': 'warn',
+    '@typescript-eslint/prefer-readonly': 'error',
     '@typescript-eslint/prefer-reduce-type-parameter': 'error',
-    '@typescript-eslint/prefer-string-starts-ends-with': 'warn',
+    '@typescript-eslint/prefer-string-starts-ends-with': 'error',
     '@typescript-eslint/promise-function-async': 'error',
-    '@typescript-eslint/require-array-sort-compare': 'warn',
+    '@typescript-eslint/require-array-sort-compare': 'error',
     '@typescript-eslint/switch-exhaustiveness-check': 'error',
-    '@typescript-eslint/unified-signatures': 'warn', // can be a bit wrong
+    '@typescript-eslint/unified-signatures': 'error', // can be a bit wrong
     'array-callback-return': 'off',
     'block-scoped-var': 'off',
     'camelcase': 'off',


### PR DESCRIPTION
Originally when I authored our configs I set a handful of rules to `warn` instead of `error` as a way of making the configs gentler and hint to people when it might be ok to actually disable the rule for that particular violation depending on the context.

In practice however, most people tend to expect the linter to block in CI and that if it doesn't then everything is fine, meaning the rules configured to `warn` were effectively the same as not being enabled at all except for when people run `--fix`.

When we've talked about this recently, the general consensus was people would prefer the rules just `error`, and so that's what this does