### PR TITLE
feat: allow `eslint-plugin-jest` v29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
         "eslint": ">= 8.0",
         "eslint-plugin-import": ">= 2.21",
-        "eslint-plugin-jest": "^28.8.0",
+        "eslint-plugin-jest": "^28.8.0 || ^29.0.0",
         "eslint-plugin-jsx-a11y": "^6.0.0",
         "eslint-plugin-n": ">= 14.0.0",
         "eslint-plugin-prettier": ">= 3.1",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
     "eslint": ">= 8.0",
     "eslint-plugin-import": ">= 2.21",
-    "eslint-plugin-jest": "^28.8.0",
+    "eslint-plugin-jest": "^28.8.0 || ^29.0.0",
     "eslint-plugin-jsx-a11y": "^6.0.0",
     "eslint-plugin-n": ">= 14.0.0",
     "eslint-plugin-prettier": ">= 3.1",


### PR DESCRIPTION
I published our new major a few days ago, which mainly just drops support for old versions of things so we can just expand our version ranges to allow it