### PR TITLE
ci: disable updating `node-version` for `actions/setup-node`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,10 @@
     {
       "matchFileNames": [".github/**"],
       "groupName": "workflows"
+    },
+    {
+      "matchDepTypes": ["uses-with"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
We want to be using the lowest major version of Node we support in CI, but still want to get major updates for the `actions/setup-node` action