### PR TITLE
feat: allow `eslint-plugin-react-hooks` v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "eslint-plugin-n": ">= 14.0.0",
         "eslint-plugin-prettier": ">= 3.1",
         "eslint-plugin-react": "^7.0.0",
-        "eslint-plugin-react-hooks": "^4.0.0 || ^5.0.0",
+        "eslint-plugin-react-hooks": "^4.0.0 || ^5.0.0 || ^6.0.0",
         "prettier": ">= 2.0"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "eslint-plugin-n": ">= 14.0.0",
     "eslint-plugin-prettier": ">= 3.1",
     "eslint-plugin-react": "^7.0.0",
-    "eslint-plugin-react-hooks": "^4.0.0 || ^5.0.0",
+    "eslint-plugin-react-hooks": "^4.0.0 || ^5.0.0 || ^6.0.0",
     "prettier": ">= 2.0"
   },
   "peerDependenciesMeta": {

--- a/react.js
+++ b/react.js
@@ -10,7 +10,7 @@ const generateConfig = () => {
     // and its likely our standard JS config will be used alongside this one
     'curly': 'error',
 
-    // todo: react-hooks does not export a flat config (yet)
+    // todo: switch to react-hooks/recommended once we require v6+
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'error',
 


### PR DESCRIPTION
The breaking change is that they've made the recommended config be flat which doesn't impact us as we enable the specific rules explicitly